### PR TITLE
increaes the timeout for the datastore cleanup

### DIFF
--- a/ckanext/dia/commands.py
+++ b/ckanext/dia/commands.py
@@ -91,6 +91,7 @@ class AdminCommand(ckan.lib.cli.CkanCommand):
 
     def _get_datastore_table_page(self, context, offset=0):
         # query datastore to get all resources from the _table_metadata
+        context['_timeout'] = 20 * 60 * 1000
         result = logic.get_action('datastore_search')(
             context,
             {


### PR DESCRIPTION
The default timeout is 1 minute, this is sensible for a web application but not for a script that is run once a day.

I've increased the timeout to 20 minutes.

Alternatively, we could reduce the paging size when searching the data-store if this is not working.

Relates to this JIRA issue: https://mediasuite.atlassian.net/browse/DATA-5