### PR TITLE
Fix/data 5 cleanup large harvests

### DIFF
--- a/ckanext/dia/commands.py
+++ b/ckanext/dia/commands.py
@@ -44,7 +44,10 @@ class AdminCommand(ckan.lib.cli.CkanCommand):
     def cleanup_datastore(self):
         for i in xrange(20):
             print 'invoking iteration %s of the cleanup_datastore_once function' % i
-            self.cleanup_datastore_once()
+            deletes, errors = self.cleanup_datastore_once()
+            if deletes == 0:
+                print 'no datastore tables remain to be deleted.'
+                break
 
     def cleanup_datastore_once(self):
         user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
@@ -93,6 +96,7 @@ class AdminCommand(ckan.lib.cli.CkanCommand):
 
         print "Deleted content of %s tables" % delete_count
         print "Deletion failed for %s tables" % delete_error_count
+        return (delete_count, delete_error_count)
 
     def _get_datastore_table_page(self, context, offset=0):
         # query datastore to get all resources from the _table_metadata

--- a/ckanext/dia/commands.py
+++ b/ckanext/dia/commands.py
@@ -42,6 +42,11 @@ class AdminCommand(ckan.lib.cli.CkanCommand):
         print self.__doc__
 
     def cleanup_datastore(self):
+        for i in xrange(20):
+            print 'invoking iteration %s of the cleanup_datastore_once function' % i
+            self.cleanup_datastore_once()
+
+    def cleanup_datastore_once(self):
         user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
         context = {
             'model': model,

--- a/ckanext/dia/commands.py
+++ b/ckanext/dia/commands.py
@@ -42,6 +42,9 @@ class AdminCommand(ckan.lib.cli.CkanCommand):
         print self.__doc__
 
     def cleanup_datastore(self):
+        # E.B 15/3/18 HACK: running the datastore 20 times in a row allows us to 
+        # get datastore table cleanup to work. Without this hack only 300 tables 
+        # will be cleaned up.
         for i in xrange(20):
             print 'invoking iteration %s of the cleanup_datastore_once function' % i
             deletes, errors = self.cleanup_datastore_once()


### PR DESCRIPTION
The datastore cleanup only works for ~300 tables. Repeat the process 20 times.

I have tested this on uat and been able to delete 1500+ tables nightly.