### PR TITLE
save temporal field when harvesting from dcat json sources

### DIFF
--- a/ckanext/dia/harvester/dcat.py
+++ b/ckanext/dia/harvester/dcat.py
@@ -193,6 +193,4 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
                 pass
 
         package_dict['groups'] = dict((group['name'], group) for group in groups).values()
-        from pprint import pformat
-        log.debug('HERE IS THE DICT {}'.format(pformat(package_dict)))
         return package_dict

--- a/ckanext/dia/harvester/dcat.py
+++ b/ckanext/dia/harvester/dcat.py
@@ -153,7 +153,8 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
             'language': lambda x: x['language'],
             'source_identifier': lambda x: x['identifier'],
             'license_url': lambda x: x['license'],
-            'license_id': lambda x: self._fetch_license_id(x['license'])
+            'license_id': lambda x: self._fetch_license_id(x['license']),
+            'temporal': lambda x: x['temporal']
         }
 
         for k, v in mappings.items():
@@ -192,4 +193,6 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
                 pass
 
         package_dict['groups'] = dict((group['name'], group) for group in groups).values()
+        from pprint import pformat
+        log.debug('HERE IS THE DICT {}'.format(pformat(package_dict)))
         return package_dict


### PR DESCRIPTION
# Issue
When harvesting from sources such as https://gist.githubusercontent.com/camfindlay/8668c4c8b5600fb17e18d15ebf75aed4/raw/76e0b49bc0559ffe988cf3af19a30d3b86072179/data.json the temporal field does not get saved.

# Solution

Add the temporal field to the mappings of fields copied from the dcat representation to the ckan representation of a dataset.