### PR TITLE
Fix issue with jsonld serialization when using a single theme

### DIFF
--- a/ckanext/dia/harvester/dcat.py
+++ b/ckanext/dia/harvester/dcat.py
@@ -198,4 +198,9 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
                 pass
 
         package_dict['groups'] = dict((group['name'], group) for group in groups).values()
+
+        if package_dict.get('theme', None) and isinstance(package_dict.get('theme'), list):
+            package_dict['theme'] = json.dumps(package_dict.get('theme'))
+
+
         return package_dict


### PR DESCRIPTION
**Issue: DATA-385**
When a dataset is harvested and it includes a  `"theme":["geospatial"]`
field.
And you view the dataset after harvesting
Then it triggers an Error message in raygun, and returns the value
`{geospatial}` for the theme

**Cause**

The dcat serialization code expects a JSON style string list of URI's
in order to render the "about" RDF triple

**Fix**

Change the dia dcat json harvester implementation.

If the dataset `theme` field is a list, then serialize it as a json
string.

Then when viewing the dataset, the ckanext-dcat plugin will parse the `theme` field as a json string,
and generate a valid RDF triple in the jsonld serialization of the dataset.