### PR TITLE
fix/package_show_api_call_not_accepting_get_requests_DATA-494

### DIFF
--- a/ckanext/dia/action/get.py
+++ b/ckanext/dia/action/get.py
@@ -14,6 +14,8 @@ from ckan.logic.action.get import _add_tracking_summary_to_resource_dict
 
 from ckan.common import _
 
+from ckantoolkit import side_effect_free
+
 log = logging.getLogger('ckan.logic')
 
 # Define some shortcuts
@@ -24,6 +26,7 @@ _get_or_bust = logic.get_or_bust
 _or_ = sqlalchemy.or_
 
 
+@side_effect_free
 def package_show(context, data_dict):
     """Return the metadata of a dataset (package) and its resources.
 


### PR DESCRIPTION
We override the `package_show` method, but we're missing the `@side_effect_free` decorator that enables parsing of the query string and ability to use the GET http method.

I've added this decorator back in, as is recommended for 3rd party modules, and the api is now working as expected again :).