### PR TITLE
Strip invalid characters from tag data in harvests

### DIFF
--- a/ckanext/dia/converters.py
+++ b/ckanext/dia/converters.py
@@ -1,3 +1,4 @@
+import re
 from logging import getLogger
 
 log = getLogger(__name__)
@@ -22,3 +23,17 @@ def fix_code_style_list(key, data, errors, context):
         if isinstance(py_list, list):
             log.info(u"Converted code-style list '{}' into text format".format(raw))
             data[key] = u' & '.join(py_list)
+
+
+def strip_invalid_tags_content(tags):
+    '''Takes a list of tag dicts, converts invalid characters to spaces
+    and then removes any duplicate spaces.'''
+
+    def convert_tag(tag):
+        # Replace bad characters with spaces
+        tag['name'] = re.sub('[^\w|^\-|^\.]', ' ', tag['name'])
+        # Remove redundant spaces
+        tag['name'] = re.sub(' {2,}', ' ', tag['name'])
+        return tag
+
+    return map(convert_tag, tags)

--- a/ckanext/dia/converters.py
+++ b/ckanext/dia/converters.py
@@ -1,4 +1,6 @@
-import logging
+from logging import getLogger
+
+log = getLogger(__name__)
 
 
 def fix_code_style_list(key, data, errors, context):
@@ -11,12 +13,12 @@ def fix_code_style_list(key, data, errors, context):
         py_list = safe_eval(raw)
     except ValueError as e:
         ## only warnings seem to make it through the CKAN logging (and appear in /var/log/apache2/ckan_default.error.log)
-        logging.warning("{} - Unable to clean value {} - already a clean string? {}".format(__name__, raw, e))
+        log.info("Unable to clean value {} - already a clean string? {}".format(raw, e))
         return None
     except Exception as e:
-        logging.warning(u"{} - Unable to clean value {} - {}".format(__name__, raw, e))
+        log.info(u"Unable to clean value {} - {}".format(raw, e))
         return None
     else:
         if isinstance(py_list, list):
-            logging.warning(u"{} - Converted code-style list '{}' into text format".format(__name__, raw))
+            log.info(u"Converted code-style list '{}' into text format".format(raw))
             data[key] = u' & '.join(py_list)

--- a/ckanext/dia/harvester/csw.py
+++ b/ckanext/dia/harvester/csw.py
@@ -8,6 +8,7 @@ import ckan.plugins as plugins
 from ckanext.spatial.interfaces import ISpatialHarvester
 from ckanext.spatial.model import MappedXmlDocument, ISOElement, ISODataFormat
 from ckan.logic.action.get import license_list
+from ckanext.dia.converters import strip_invalid_tags_content
 from pyproj import Proj, transform
 from clean_frequency import clean_frequency
 
@@ -215,6 +216,7 @@ class DIASpatialHarvester(plugins.SingletonPlugin):
             conf = {}
 
         tags = package_dict.get('tags', [])
+        tags = strip_invalid_tags_content(tags)
         tags.extend(conf.get('default_tags', []))
         package_dict['tags'] = dict((tag['name'], tag) for tag in tags).values()
 

--- a/ckanext/dia/harvester/dcat.py
+++ b/ckanext/dia/harvester/dcat.py
@@ -3,12 +3,12 @@ from string import Template
 import json
 
 import requests
-import re
 
 from ckan import model
 import ckan.plugins as plugins
 from ckan.logic.action.get import license_list
 from ckanext.dcat.harvesters import DCATJSONHarvester
+from ckanext.dia.converters import strip_invalid_tags_content
 from clean_frequency import clean_frequency
 
 log = getLogger(__name__)
@@ -153,20 +153,6 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
         return package_dict, dcat_dict
 
 
-    def _strip_invalid_tags_content(self, tags):
-        '''Takes a list of tag dicts, converts invalid characters to spaces
-        and then removes any duplicate spaces.'''
-
-        def convert_tag(tag):
-            # Replace bad characters with spaces
-            tag['name'] = re.sub('[^\w|^\-|^\.]', ' ', tag['name'])
-            # Remove redundant spaces
-            tag['name'] = re.sub(' {2,}', ' ', tag['name'])
-            return tag
-
-        return map(convert_tag, tags)
-
-
     def modify_package_dict(self, package_dict, dcat_dict, harvest_object):
         try:
             conf = json.loads(harvest_object.source.config)
@@ -176,7 +162,7 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
             conf = {}
 
         tags = package_dict.get('tags', [])
-        tags = self._strip_invalid_tags_content(tags)
+        tags = strip_invalid_tags_content(tags)
         tags.extend(conf.get('default_tags', []))
         package_dict['tags'] = dict((tag['name'], tag) for tag in tags).values()
 

--- a/ckanext/dia/plugin.py
+++ b/ckanext/dia/plugin.py
@@ -16,7 +16,7 @@ class DIAValidationPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IValidators)
 
     def update_config(self, config):
-        # monkeypatching isodate and extra_key_not_in_root_schema validators
+        # monkeypatching validators
         ckan.logic.validators.isodate = validators.isodate
         ckan.logic.validators.extra_key_not_in_root_schema = validators.extra_key_not_in_root_schema
 


### PR DESCRIPTION
We've had issues with some harvest/dataset definitions failing due to restrictions in the allowed characters in tags.

The decision was to remove any invalid characters in this plugin, so that validation should always pass. Invalid characters are replaced with spaces, and then the spaces are consolidated down to one.

"Things & Stuff" is not a valid tag, as the validation ensures that word characters, `-`, and `.` are the only characters allowed. After this change, the above tag would become "Things Stuff", and would then pass validation.