### PR TITLE
Add custom header to harvest requests

### DIFF
--- a/ckanext/dia/harvester/dcat.py
+++ b/ckanext/dia/harvester/dcat.py
@@ -10,9 +10,11 @@ from urllib.parse import urlparse
 import requests
 
 from ckan import model
+import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 from ckan.logic.action.get import license_list
 from ckanext.dcat.harvesters import DCATJSONHarvester
+from ckanext.dcat.interfaces import IDCATRDFHarvester
 from ckanext.dia.converters import strip_invalid_tags_content
 from ckanext.dia.harvester.clean_frequency import clean_frequency
 
@@ -20,6 +22,7 @@ log = getLogger(__name__)
 
 
 class DIADCATJSONHarvester(DCATJSONHarvester):
+    p.implements(IDCATRDFHarvester, inherit=True)
 
     extent_template = Template('''
         {
@@ -35,6 +38,11 @@ class DIADCATJSONHarvester(DCATJSONHarvester):
             ]
         }
     ''')
+
+    # IDCATRDFHarvester
+    def update_session(self, session):
+        session.headers.update({'X-Harvest': 'data.govt.nz/dcat-json'})
+        return session
 
     def _clean_email(self, email):
         if email.startswith("mailto:"):


### PR DESCRIPTION
Note that this only adds this header on DCAT JSON Harvest requests, and other harvesters used by catalogue.data.govt.nz do not implement the same interface (and use a variety of different request libraries) so would require further work to manage this across all harvesters.

The intent of this work is to provide publishing organisations a way to whitelist requests for their dataset/resource files and allow them through their WAF.