### PR TITLE
Add API endpoint to report on datapusher errors

### DIFF
--- a/ckanext/dia/plugin/__init__.py
+++ b/ckanext/dia/plugin/__init__.py
@@ -62,6 +62,15 @@ class DIAUriMintingPlugin(p.SingletonPlugin):
         tk.add_template_directory(config, '../templates')
 
 
+class DIAAPIPlugin(p.SingletonPlugin):
+    p.implements(p.IBlueprint)
+
+    # IBlueprint
+
+    def get_blueprint(self):
+        return views.api
+
+
 class DIANoHomepagePlugin(DIANoHomepageMixin, p.SingletonPlugin):
     """
     Redirect / to /dataset

--- a/ckanext/dia/views.py
+++ b/ckanext/dia/views.py
@@ -129,7 +129,7 @@ def edit_uri(uri_id):
     return tk.render('uris/edit.html', extra_vars=vars)
 
 
-api = Blueprint(u'dia-api', __name__, url_prefix=u'/dia-api')
+api = Blueprint(u'dia-api', __name__, url_prefix=u'/api')
 
 @api.route('/datapusher-health', methods=['GET', 'POST'])
 def datapusher_health():
@@ -144,10 +144,17 @@ def datapusher_health():
 
     headers = {"Content-Type": "application/json;charset=utf-8"}
 
-    if query.count() > 0:
+    error_count = query.count()
+
+    if error_count > 0:
         data = [model_dictize.task_status_dictize(ts, {'task_status': ts}) for ts in query.all()]
-        response_msg = json.dumps(data)
-        return make_response((response_msg, 500, headers))
+        response_msg = json.dumps({
+            "error": {
+                "message": f"{error_count} datapusher tasks errored in the last day",
+                "detail": data
+            }
+        })
+        return make_response((response_msg, 503, headers))
 
     response_msg = json.dumps({})
     return make_response((response_msg, 200, headers))

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     dianohomepage=ckanext.dia.plugin:DIANoHomepagePlugin
     diacommands=ckanext.dia.plugin:DIACommandsPlugin
     diauriminting=ckanext.dia.plugin:DIAUriMintingPlugin
+    diaapi=ckanext.dia.plugin:DIAAPIPlugin
 
     [paste.paster_command]
     admin=ckanext.dia.commands:AdminCommand


### PR DESCRIPTION
API endpoint returns 500 on datapusher errors, with info about the affected resource and the error that occurred.

Intent is to hit this from pingdom or similar and alert on it.